### PR TITLE
WIP: Add setTurnSpeed and setMovementSpeed commands

### DIFF
--- a/servolite.ts
+++ b/servolite.ts
@@ -139,23 +139,23 @@ namespace kitronik_servo_lite {
     }
 
 	/**
-     * Allows the setting of the :MOVE mini turn speed.
+     * Allows the setting of the :MOVE mini turn degrees per second.
      * This allows tuning for the turn x degrees commands
      * @param degPerSec : How many degrees per second the mini does.
      */
     //% blockId=kitronik_servolite_set_turn_speed_param
-    //% block="calibrate turn speed to %DegPerSec|degrees per second" 
+    //% block="calibrate turn amount to %degPerSec|degrees per second"
     export function setDegreesPerSecond(degPerSec: number): void {
         numberOfDegreesPerSec = degPerSec
     }
 
     /**
-     * Allows the setting of the :MOVE mini forward / reverse speed.
+     * Allows the setting of the :MOVE mini distance per second.
      * This allows tuning for the move x distance commands
-     * @param DegPerSec : How many degrees per second the mini does.
+     * @param distPerSec : How many mm per second the mini moves.
      */
-    //% blockId=kitronik_servolite_set_movement_speed_param 
-    //% block="calibrate forward speed to %DistPerSec|mm per second"
+    //% blockId=kitronik_servolite_set_movement_speed_param
+    //% block="calibrate movement amount to %distPerSec|mm per second"
     export function setDistancePerSecond(distPerSec: number): void {
         distancePerSec = distPerSec
     }

--- a/servolite.ts
+++ b/servolite.ts
@@ -12,6 +12,8 @@ namespace kitronik_servo_lite {
     const microSecInASecond = 1000000
     let distancePerSec = 100
     let numberOfDegreesPerSec = 200
+    let movementSpeed = 1
+    let turnSpeed = 1
 
     /**
      * Drives forwards. Call stop to stop
@@ -19,8 +21,9 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_servos_forward
     //% block="drive forward"
     export function forward(): void {
-        pins.servoWritePin(AnalogPin.P1, 0);
-        pins.servoWritePin(AnalogPin.P2, 180);
+        let speed = Math.round(90 * movementSpeed);
+        pins.servoWritePin(AnalogPin.P1, 90 - speed);
+        pins.servoWritePin(AnalogPin.P2, 90 + speed);
     }
 
     /**
@@ -29,8 +32,9 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_servos_backward
     //% block="drive backward"
     export function backward(): void {
-        pins.servoWritePin(AnalogPin.P1, 180);
-        pins.servoWritePin(AnalogPin.P2, 0);
+        let speed = Math.round(90 * movementSpeed);
+        pins.servoWritePin(AnalogPin.P1, 90 + speed);
+        pins.servoWritePin(AnalogPin.P2, 90 - speed);
     }
 
     /**
@@ -39,8 +43,9 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_servos_left
     //% block="turn left"
     export function left(): void {
-        pins.servoWritePin(AnalogPin.P1, 0);
-        pins.servoWritePin(AnalogPin.P2, 0);
+        let speed = Math.round(90 - 90 * turnSpeed);
+        pins.servoWritePin(AnalogPin.P1, speed);
+        pins.servoWritePin(AnalogPin.P2, speed);
     }
 
 	/**
@@ -49,8 +54,9 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_servos_right
     //% block="turn right"
     export function right(): void {
-        pins.servoWritePin(AnalogPin.P1, 180);
-        pins.servoWritePin(AnalogPin.P2, 180);
+        let speed = Math.round(90 + 90 * turnSpeed);
+        pins.servoWritePin(AnalogPin.P1, speed);
+        pins.servoWritePin(AnalogPin.P2, speed);
     }
 
 	/**
@@ -85,7 +91,7 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_drive_forwards
     //% block="drive forwards %howFar|distance" 
     export function driveForwards(howFar: number): void {
-        let timeToWait = (howFar * microSecInASecond) / distancePerSec; // calculation done this way round to avoid zero rounding
+        let timeToWait = (howFar * microSecInASecond) / distancePerSec * (1 / movementSpeed); // calculation done this way round to avoid zero rounding
         forward();
         control.waitMicros(timeToWait);
         stop();
@@ -98,7 +104,7 @@ namespace kitronik_servo_lite {
     //% blockId=kitronik_servolite_drive_backwards
     //% block="drive backwards %howFar|distance" 
     export function driveBackwards(howFar: number): void {
-        let timeToWait = (howFar * microSecInASecond) / distancePerSec; // calculation done this way round to avoid zero rounding
+        let timeToWait = (howFar * microSecInASecond) / distancePerSec * (1 / movementSpeed); // calculation done this way round to avoid zero rounding
         backward();
         control.waitMicros(timeToWait);
         stop();
@@ -152,11 +158,33 @@ namespace kitronik_servo_lite {
     /**
      * Allows the setting of the :MOVE mini distance per second.
      * This allows tuning for the move x distance commands
+     * Only measure this when the move speed is 100%.
      * @param distPerSec : How many mm per second the mini moves.
      */
     //% blockId=kitronik_servolite_set_movement_speed_param
     //% block="calibrate movement amount to %distPerSec|mm per second"
     export function setDistancePerSecond(distPerSec: number): void {
         distancePerSec = distPerSec
+    }
+
+    /**
+     * Allows the setting of the :MOVE mini turn speed.
+     * Does not affect the turn x degrees commands.
+     * @param percent : Speed percentage from 1% to 100%.
+     */
+    //% blockId=kitronik_servolite_set_turn_speed_percent
+    //% block="set turn speed to %percent|percent"
+    export function setTurnSpeed(percent: number): void {
+        turnSpeed = percent / 100
+    }
+
+    /**
+     * Allows the setting of the :MOVE mini movement speed.
+     * @param percent : Speed percentage from 1% to 100%.
+     */
+    //% blockId=kitronik_servolite_set_movement_speed_percent
+    //% block="set movement speed to %percent|percent"
+    export function setMovementSpeed(percent: number): void {
+        movementSpeed = percent / 100
     }
 }


### PR DESCRIPTION
I've tried to add commands to allow you to adjust the turn and movement speed, as opposed to the amount per second. It's not really working yet though and I don't know why. There seems to be little to no change in speed until it gets below around 30% and then it drops very rapidly. At the slowest speeds, trying to move forwards or backwards only turns one wheel. My maths is a bit rusty but I'm guessing you can't adjust the numbers linearly in this way? Is it logarithmic? Or maybe the servos don't allow for such fine-grained control?

Obviously this requires float support in MakeCode and I did see #11 so I have been using the beta version, although I suspect this feature is already in the stable version now.